### PR TITLE
OSW-610: faster BumpTest output, colorize terminal, use DurationParser

### DIFF
--- a/doc/version-history.rst
+++ b/doc/version-history.rst
@@ -4,6 +4,11 @@
 Version History
 ===============
 
+v0.3.1
+------
+
+* Improved bump_test_times querying and reporting.
+
 v0.3.0
 ------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
   "pandas",
   "PySide6",
   "scipy",
+  "sty",
   "tqdm",
   "ts_xml",
   "lsst_efd_client",

--- a/python/lsst/ts/m1m3/utils/acceleration_and_velocity.py
+++ b/python/lsst/ts/m1m3/utils/acceleration_and_velocity.py
@@ -1,4 +1,4 @@
-# This file is part of ts_aos_utils.
+# This file is part of ts_m1m3_utils.
 #
 # Developed for the LSST Data Management System.
 # This product includes software developed by the LSST Project

--- a/python/lsst/ts/m1m3/utils/acceleration_and_velocity_fitter.py
+++ b/python/lsst/ts/m1m3/utils/acceleration_and_velocity_fitter.py
@@ -1,4 +1,4 @@
-# This file is part of M1M3 SS GUI.
+# This file is part of ts_m1m3_utils.
 #
 # Developed for the LSST Telescope and Site Systems.
 # This product includes software developed by the LSST Project

--- a/python/lsst/ts/m1m3/utils/bump_test_runner.py
+++ b/python/lsst/ts/m1m3/utils/bump_test_runner.py
@@ -1,4 +1,4 @@
-# This file is part of M1M3 GUI.
+# This file is part of ts_m1m3_utils.
 #
 # Developed for the LSST Telescope and Site Systems.  This product includes
 # software developed by the LSST Project (https://www.lsst.org).  See the

--- a/python/lsst/ts/m1m3/utils/bump_test_times.py
+++ b/python/lsst/ts/m1m3/utils/bump_test_times.py
@@ -18,14 +18,36 @@
 # You should have received a copy of the GNU General Public License along with
 # this program. If not, see <https://www.gnu.org/licenses/>.
 
+from dataclasses import dataclass
+from typing import AsyncGenerator
+
 from astropy.time import Time, TimeDelta
-from lsst.ts.xml.tables.m1m3 import FAType, force_actuator_from_id
+from lsst.ts.xml.enums.MTM1M3 import BumpTest as BumpTestStatus
+from lsst.ts.xml.tables.m1m3 import ForceActuatorData
 from lsst_efd_client import EfdClient
+
+
+@dataclass
+class BumpTest:
+    """Represent a single bump test occurence.
+
+    Attributes
+    ----------
+    fa : `ForceActuatorData`
+    start_time : `Time`
+    end_time : `Time`
+    result : `int`
+    """
+
+    fa: ForceActuatorData
+    start_time: Time
+    end_time: Time
+    result: int | None
 
 
 class BumpTestTimes:
     """Returns a set of times for bump tests given the actuator ID and
-    an input timespan
+    a time range.
 
     Parameters
     ----------
@@ -39,71 +61,58 @@ class BumpTestTimes:
 
     async def find_times(
         self,
-        actuator_id: int,
+        fa: ForceActuatorData,
+        primary: bool,
         start: Time = (Time.now() - TimeDelta(7, format="jd")),
         end: Time = Time.now(),
-    ) -> tuple[list[tuple[Time, Time]], list[tuple[Time, Time]]]:
+    ) -> AsyncGenerator[BumpTest, None]:
         """Find bump test query times
-        actuator_id : `int`
+
+        Parameters
+        ----------
+        fa : `ForceActuatorData`
             Force Actuator identification number. Starting with 101, the first
             number identified segment (1-4). The value ranges up to 443.
-
         start: 'Time', optional
             Astropy Time of search start. Defaults to week ago.
-
         end: Time
             Astropy Time of search end. Defaults to current time.
 
-        returns: Two nested list of Time, one for the primary bump and one for
-            the secondary bump [start,end], [start, end]...].
+        Returns
+        -------
+        tests : `[BumpTest]`
+            List of performed bump tests.
         """
-        fa = force_actuator_from_id(actuator_id)
-
         # Find the test names
-        primary_bump = f"primaryTest{fa.index}"
-        query_fields = ["time", primary_bump]
-        if fa.actuator_type == FAType.DAA:
-            secondary_bump = f"secondaryTest{fa.s_index}"
-            query_fields.append(secondary_bump)
-        else:
-            secondary_bump = None
+        status = f"primaryTest{fa.index}" if primary else f"secondaryTest{fa.s_index}"
 
-        bumps = await self.client.select_time_series(
-            "lsst.sal.MTM1M3.logevent_forceActuatorBumpTestStatus",
-            query_fields,
-            start,
-            end,
+        query = (
+            f"SELECT time, {status} "
+            'FROM "efd"."autogen"."lsst.sal.MTM1M3.logevent_forceActuatorBumpTestStatus" '
+            f"WHERE time >= '{start.isot}Z' AND time <= '{end.isot}Z' "
+            f"AND {status} = {BumpTestStatus.TRIGGERED}"
         )
+        bumps = await self.client._do_query(query)
+
+        end_time: Time | None = None
 
         # Now find the separate tests
-        times = bumps.index
-        start_times = []
-        end_times = []
-        for i, time in enumerate(times):
-            if i == 0:
-                start_times.append(time)
+        for time, row in bumps.iterrows():
+            start_time = Time(time)
+            if end_time is not None and start_time < end_time:
                 continue
-            if (time - times[i - 1]) > TimeDelta(60.0, format="sec"):
-                start_times.append(time)
-                end_times.append(times[i - 1])
-        end_times.append(times[-1])
-        # Now use these to find the bump test start and end times
-        primary_times: list[tuple[Time, Time]] = []
-        secondary_times: list[tuple[Time, Time]] = []
-        for start_time, end_time in zip(start_times, end_times):
-            this_bump = bumps[(bumps.index >= start_time) & (bumps.index <= end_time)]
-            try:
-                plot_start = Time(
-                    this_bump[this_bump[primary_bump] == 2].index[0]
-                ) - TimeDelta(1, format="sec")
-                plot_end = plot_start + TimeDelta(14, format="sec")
-                primary_times.append((plot_start, plot_end))
-                if secondary_bump is not None:
-                    plot_start = Time(
-                        this_bump[this_bump[secondary_bump] == 2].index[0]
-                    ) - TimeDelta(1, format="sec")
-                    plot_end = plot_start + TimeDelta(14, format="sec")
-                    secondary_times.append((plot_start, plot_end))
-            except IndexError:
-                continue
-        return primary_times, secondary_times
+
+            end_time = start_time + TimeDelta(60, format="sec")
+
+            ends = await self.client._do_query(
+                f"SELECT time, {status} "
+                'FROM "efd"."autogen"."lsst.sal.MTM1M3.logevent_forceActuatorBumpTestStatus" '
+                f"WHERE time > '{start_time.isot}Z' "
+                f"AND time <= '{end_time.isot}Z' "
+                f"AND {status} >= {BumpTestStatus.PASSED}"
+            )
+            if len(ends) == 0:
+                yield BumpTest(fa, start_time, None, None)
+            else:
+                end_time = Time(ends.index[0])
+                yield BumpTest(fa, start_time, end_time, ends[status].iloc[0])

--- a/python/lsst/ts/m1m3/utils/bump_test_times.py
+++ b/python/lsst/ts/m1m3/utils/bump_test_times.py
@@ -65,6 +65,7 @@ class BumpTestTimes:
         primary: bool,
         start: Time = (Time.now() - TimeDelta(7, format="jd")),
         end: Time = Time.now(),
+        start_delta: TimeDelta = TimeDelta(3, format="sec"),
     ) -> AsyncGenerator[BumpTest, None]:
         """Find bump test query times
 
@@ -73,10 +74,14 @@ class BumpTestTimes:
         fa : `ForceActuatorData`
             Force Actuator identification number. Starting with 101, the first
             number identified segment (1-4). The value ranges up to 443.
+        primary : `bool`
+            If true, search primary cylinder (Z) bump tests.
         start: 'Time', optional
             Astropy Time of search start. Defaults to week ago.
-        end: Time
+        end: `Time`
             Astropy Time of search end. Defaults to current time.
+        start_delta : `TimeDelta`, optional
+            Delta to subtract from start of the tests. Defaults to 3 seconds.
 
         Returns
         -------
@@ -90,7 +95,7 @@ class BumpTestTimes:
             f"SELECT time, {status} "
             'FROM "efd"."autogen"."lsst.sal.MTM1M3.logevent_forceActuatorBumpTestStatus" '
             f"WHERE time >= '{start.isot}Z' AND time <= '{end.isot}Z' "
-            f"AND {status} = {BumpTestStatus.TRIGGERED}"
+            f"AND {status} = {BumpTestStatus.TESTINGPOSITIVE}"
         )
         bumps = await self.client._do_query(query)
 
@@ -111,6 +116,7 @@ class BumpTestTimes:
                 f"AND time <= '{end_time.isot}Z' "
                 f"AND {status} >= {BumpTestStatus.PASSED}"
             )
+            start_time -= start_delta
             if len(ends) == 0:
                 yield BumpTest(fa, start_time, None, None)
             else:

--- a/python/lsst/ts/m1m3/utils/bump_test_times.py
+++ b/python/lsst/ts/m1m3/utils/bump_test_times.py
@@ -61,17 +61,18 @@ class BumpTestTimes:
 
         # Find the test names
         primary_bump = f"primaryTest{fa.index}"
-        query_fields = "time, " + primary_bump
+        query_fields = ["time", primary_bump]
         if fa.actuator_type == FAType.DAA:
             secondary_bump = f"secondaryTest{fa.s_index}"
-            query_fields += ", " + secondary_bump
+            query_fields.append(secondary_bump)
         else:
             secondary_bump = None
 
-        bumps = await self.client.influx_client.query(
-            f"SELECT {query_fields} "
-            'FROM "efd"."autogen"."lsst.sal.MTM1M3.logevent_forceActuatorBumpTestStatus" '
-            f"WHERE time >= '{start.isot}+00:00' AND time <= '{end.isot}+00:00'"
+        bumps = await self.client.select_time_series(
+            "lsst.sal.MTM1M3.logevent_forceActuatorBumpTestStatus",
+            query_fields,
+            start,
+            end,
         )
 
         # Now find the separate tests

--- a/python/lsst/ts/m1m3/utils/bump_test_times.py
+++ b/python/lsst/ts/m1m3/utils/bump_test_times.py
@@ -1,4 +1,4 @@
-# This file is part of M1M3 GUI.
+# This file is part of ts_m1m3_utils.
 #
 # Developed for the LSST Telescope and Site Systems.  This product includes
 # software developed by the LSST Project (https://www.lsst.org).  See the

--- a/python/lsst/ts/m1m3/utils/duration_time.py
+++ b/python/lsst/ts/m1m3/utils/duration_time.py
@@ -1,4 +1,4 @@
-# This file is part of M1M3 SS GUI.
+# This file is part of ts_m1m3_utils.
 #
 # Developed for the LSST Telescope and Site Systems.
 # This product includes software developed by the LSST Project

--- a/python/lsst/ts/m1m3/utils/duration_time.py
+++ b/python/lsst/ts/m1m3/utils/duration_time.py
@@ -34,6 +34,7 @@ def parse_duration(duration: str) -> TimeDelta:
 
     Length denominators
     -------------------
+    W : weeks (7 * 86400 seconds)
     D : days (86400 seconds)
     h : hours (3600 seconds)
     m : minutes (60 seconds)
@@ -55,7 +56,15 @@ def parse_duration(duration: str) -> TimeDelta:
     seconds : float
         Number of seconds in string.
     """
-    muls = {"D": 86400, "h": 3600, "m": 60, "s": 1, "u": 0.001, "n": 0.000001}
+    muls = {
+        "W": 604800,
+        "D": 86400,
+        "h": 3600,
+        "m": 60,
+        "s": 1,
+        "u": 0.001,
+        "n": 0.000001,
+    }
     ret: float = 0.0
     current: float = 0.0
     duration = duration.strip()

--- a/python/lsst/ts/m1m3/utils/force_actuator_forces.py
+++ b/python/lsst/ts/m1m3/utils/force_actuator_forces.py
@@ -1,4 +1,4 @@
-# This file is part of M1M3 GUI.
+# This file is part of ts_m1m3_utils.
 #
 # Developed for the LSST Telescope and Site Systems.  This product includes
 # software developed by the LSST Project (https://www.lsst.org).  See the

--- a/python/lsst/ts/m1m3/utils/force_calculator.py
+++ b/python/lsst/ts/m1m3/utils/force_calculator.py
@@ -1,4 +1,4 @@
-# This file is part of M1M3 SS GUI.
+# This file is part of ts_m1m3_utils.
 #
 # Developed for the LSST Telescope and Site Systems.
 # This product includes software developed by the LSST Project

--- a/python/lsst/ts/m1m3/utils/m1m3_bump_tests_times.py
+++ b/python/lsst/ts/m1m3/utils/m1m3_bump_tests_times.py
@@ -26,7 +26,9 @@ import asyncio
 import logging
 from urllib.parse import urlencode, urlunparse
 
+import sty
 from astropy.time import Time, TimeDelta
+from lsst.ts.xml.enums.MTM1M3 import BumpTest as BumpTestStatus
 from lsst.ts.xml.tables.m1m3 import FATable, force_actuator_from_id
 from lsst_efd_client import EfdClient
 
@@ -109,10 +111,16 @@ async def run_loop() -> None:
         async def print_bump(test: BumpTest) -> None:
             params = {
                 "refresh": "Paused",
-                "tempVars[x_index]": test.fa.x_index,
-                "tempVars[y_index]": test.fa.y_index,
-                "tempVars[z_index]": test.fa.z_index,
-                "tempVars[s_index]": test.fa.s_index,
+                "tempVars[x_index]": (
+                    0 if test.fa.x_index is None else test.fa.actuator_id
+                ),
+                "tempVars[y_index]": (
+                    0 if test.fa.y_index is None else test.fa.actuator_id
+                ),
+                "tempVars[z_index]": test.fa.actuator_id,
+                "tempVars[s_index]": (
+                    0 if test.fa.s_index is None else test.fa.actuator_id
+                ),
                 "lower": test.start_time.isot + "Z",
                 "upper": test.end_time.isot + "Z",
             }
@@ -134,7 +142,14 @@ async def run_loop() -> None:
                     "",
                 )
             )
-            print(test.start_time.isot, test.end_time.isot, test.result, url)
+            print(
+                sty.fg.green if test.result == BumpTestStatus.PASSED else sty.fg.red,
+                test.start_time.isot,
+                test.end_time.isot,
+                test.result,
+                sty.fg.rs,
+                url,
+            )
             if args.details:
                 faf = ForceActuatorForces(test.start_time, test.end_time, client)
                 fa_fe = await faf.actuator_following_error(actuator)
@@ -149,13 +164,18 @@ async def run_loop() -> None:
                     f"max {flat_fe.max():.3f} N"
                 )
 
-        print("Primary bump tests - FA ", actuator.actuator_id)
+        print(sty.fg.yellow, "Primary bump tests - FA", actuator.actuator_id, sty.bg.rs)
         async for bump in btt.find_times(actuator, True, start_t, end_t):
             await print_bump(bump)
 
         if actuator.s_index is not None:
-            print("===================")
-            print("Secondary bump tests - FA ", actuator.actuator_id)
+            print(sty.bg.blue, "\u25A9" * 50, sty.bg.rs)
+            print(
+                sty.fg.yellow,
+                "Secondary bump tests - FA",
+                actuator.actuator_id,
+                sty.fg.rs,
+            )
             async for bump in btt.find_times(actuator, False, start_t, end_t):
                 await print_bump(bump)
 

--- a/python/lsst/ts/m1m3/utils/m1m3_bump_tests_times.py
+++ b/python/lsst/ts/m1m3/utils/m1m3_bump_tests_times.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # This file is part of ts_m1m3_utils
 #
 # Developed for the LSST Telescope and Site.

--- a/python/lsst/ts/m1m3/utils/m1m3_bump_tests_times.py
+++ b/python/lsst/ts/m1m3/utils/m1m3_bump_tests_times.py
@@ -27,11 +27,12 @@ import logging
 from urllib.parse import urlencode, urlunparse
 
 from astropy.time import Time, TimeDelta
-from lsst.ts.m1m3.utils import BumpTestTimes, ForceActuatorForces
-from lsst.ts.xml.tables.m1m3 import FATable, ForceActuatorData, force_actuator_from_id
+from lsst.ts.xml.tables.m1m3 import FATable, force_actuator_from_id
 from lsst_efd_client import EfdClient
 
+from .bump_test_times import BumpTest, BumpTestTimes
 from .duration_time import DurationTime
+from .force_actuator_forces import ForceActuatorForces
 
 
 def parse_arguments() -> argparse.Namespace:
@@ -104,20 +105,16 @@ async def run_loop() -> None:
     for aid in [int(a) for a in args.actuators]:
         actuator = force_actuator_from_id(aid)
         logging.info(f"** Actuator {aid} type: {actuator.actuator_type}")
-        primary, secondary = await btt.find_times(aid, start_t, end_t)
 
-        async def print_bump(start: Time, end: Time) -> None:
-            def act(index: int | None, actuator: ForceActuatorData) -> int:
-                return 0 if index is None else actuator
-
+        async def print_bump(test: BumpTest) -> None:
             params = {
                 "refresh": "Paused",
-                "tempVars[x_index]": act(actuator.x_index, actuator.actuator_id),
-                "tempVars[y_index]": act(actuator.y_index, actuator.actuator_id),
-                "tempVars[z_index]": actuator.actuator_id,
-                "tempVars[s_index]": act(actuator.s_index, actuator.actuator_id),
-                "lower": start.isot + "Z",
-                "upper": end.isot + "Z",
+                "tempVars[x_index]": test.fa.x_index,
+                "tempVars[y_index]": test.fa.y_index,
+                "tempVars[z_index]": test.fa.z_index,
+                "tempVars[s_index]": test.fa.s_index,
+                "lower": test.start_time.isot + "Z",
+                "upper": test.end_time.isot + "Z",
             }
             url = urlunparse(
                 (
@@ -137,9 +134,9 @@ async def run_loop() -> None:
                     "",
                 )
             )
-            print(start.isot, end.isot, url)
+            print(test.start_time.isot, test.end_time.isot, test.result, url)
             if args.details:
-                faf = ForceActuatorForces(start, end, client)
+                faf = ForceActuatorForces(test.start_time, test.end_time, client)
                 fa_fe = await faf.actuator_following_error(actuator)
                 print(
                     f"Following errors min: {fa_fe.primary.min():.3f} N "
@@ -152,16 +149,20 @@ async def run_loop() -> None:
                     f"max {flat_fe.max():.3f} N"
                 )
 
-        print("Primary bump tests")
-        for bump in primary:
-            await print_bump(bump[0], bump[1])
+        print("Primary bump tests - FA ", actuator.actuator_id)
+        async for bump in btt.find_times(actuator, True, start_t, end_t):
+            await print_bump(bump)
 
-        print("===================")
-        print("Secondary bump tests")
-        for bump in secondary:
-            await print_bump(bump[0], bump[1])
+        if actuator.s_index is not None:
+            print("===================")
+            print("Secondary bump tests - FA ", actuator.actuator_id)
+            async for bump in btt.find_times(actuator, False, start_t, end_t):
+                await print_bump(bump)
 
-    await client._influx_client.close()
+    if client.influx_client is None:
+        await client._influx_client.close()
+    else:
+        await client.influx_client.close()
 
 
 def run() -> None:

--- a/python/lsst/ts/m1m3/utils/m1m3_bump_tests_times.py
+++ b/python/lsst/ts/m1m3/utils/m1m3_bump_tests_times.py
@@ -31,6 +31,8 @@ from lsst.ts.m1m3.utils import BumpTestTimes, ForceActuatorForces
 from lsst.ts.xml.tables.m1m3 import FATable, ForceActuatorData, force_actuator_from_id
 from lsst_efd_client import EfdClient
 
+from .duration_time import DurationTime
+
 
 def parse_arguments() -> argparse.Namespace:
     """Parse command line arguments."""
@@ -40,14 +42,14 @@ def parse_arguments() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Queries bump test status.")
     parser.add_argument(
         "start_time",
-        type=Time,
+        type=DurationTime(now),
         default=now - TimeDelta(7, format="jd"),
         nargs="?",
         help="Start time in a valid format: 'YYYY-MM-DD HH:MM:SSZ'",
     )
     parser.add_argument(
         "end_time",
-        type=Time,
+        type=DurationTime(now),
         default=now,
         nargs="?",
         help="End time in a valid format: 'YYYY-MM-DD HH:MM:SSZ'",
@@ -81,6 +83,8 @@ def parse_arguments() -> argparse.Namespace:
 async def run_loop() -> None:
     args = parse_arguments()
 
+    start_t, end_t = DurationTime.pair(args.start_time, args.end_time)
+
     level = logging.INFO
 
     if args.d:
@@ -100,7 +104,7 @@ async def run_loop() -> None:
     for aid in [int(a) for a in args.actuators]:
         actuator = force_actuator_from_id(aid)
         logging.info(f"** Actuator {aid} type: {actuator.actuator_type}")
-        primary, secondary = await btt.find_times(aid, args.start_time, args.end_time)
+        primary, secondary = await btt.find_times(aid, start_t, end_t)
 
         async def print_bump(start: Time, end: Time) -> None:
             def act(index: int | None, actuator: ForceActuatorData) -> int:

--- a/python/lsst/ts/m1m3/utils/m1m3_do_bump_tests.py
+++ b/python/lsst/ts/m1m3/utils/m1m3_do_bump_tests.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # This file is part of ts_m1m3_utils
 #
 # Developed for the LSST Telescope and Site.

--- a/python/lsst/ts/m1m3/utils/m1m3_fe_outliers.py
+++ b/python/lsst/ts/m1m3/utils/m1m3_fe_outliers.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # This file is part of ts_m1m3_utils
 #
 # Developed for the LSST Telescope and Site.

--- a/python/lsst/ts/m1m3/utils/simulator.py
+++ b/python/lsst/ts/m1m3/utils/simulator.py
@@ -1,4 +1,4 @@
-# This file is part of M1M3 SS GUI.
+# This file is part of ts_m1m3_utils.
 #
 # Developed for the LSST Telescope and Site Systems.
 # This product includes software developed by the LSST Project

--- a/tests/test_aav.py
+++ b/tests/test_aav.py
@@ -1,4 +1,4 @@
-# This file is part of ts_mtmount.
+# This file is part of ts_m1m3_utils.
 #
 # Developed for Rubin Observatory Telescope and Site Systems.
 # This product includes software developed by the LSST Project

--- a/tests/test_bump_test_times.py
+++ b/tests/test_bump_test_times.py
@@ -23,6 +23,7 @@ import unittest
 
 from astropy.time import Time
 from lsst.ts.m1m3.utils import BumpTestTimes
+from lsst.ts.xml.tables.m1m3 import force_actuator_from_id
 from lsst_efd_client import EfdClient
 
 
@@ -32,10 +33,41 @@ class BumpTestTimesTestCase(unittest.IsolatedAsyncioTestCase):
         self.btt = BumpTestTimes(self.client)
 
     async def asyncTearDown(self) -> None:
-        await self.client.influx_client.close()
+        try:
+            await self.client._influx_client.close()
+        except AttributeError:
+            await self.client.influx_client.close()
+
+    async def get_tests(
+        self, actuator_id: int, start_t: Time, end_t: Time
+    ) -> tuple[BumpTestTimes, BumpTestTimes]:
+        fa = force_actuator_from_id(actuator_id)
+        primary = tuple(
+            [
+                tt
+                async for tt in self.btt.find_times(
+                    fa,
+                    True,
+                    Time("2024-09-09 13:28:04"),
+                    Time("2024-09-16 13:28:04"),
+                )
+            ]
+        )
+        secondary = tuple(
+            [
+                tt
+                async for tt in self.btt.find_times(
+                    fa,
+                    False,
+                    Time("2024-09-09 13:28:04"),
+                    Time("2024-09-16 13:28:04"),
+                )
+            ]
+        )
+        return (primary, secondary)
 
     async def test_times_saa(self) -> None:
-        primary, secondary = await self.btt.find_times(
+        primary, secondary = await self.get_tests(
             101, Time("2024-09-09 13:28:04"), Time("2024-09-16 13:28:04")
         )
 
@@ -43,7 +75,7 @@ class BumpTestTimesTestCase(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(len(secondary), 0)
 
     async def test_times_daa(self) -> None:
-        primary, secondary = await self.btt.find_times(
+        primary, secondary = await self.get_tests(
             435, Time("2024-09-09 13:28:04"), Time("2024-09-16 13:28:04")
         )
 

--- a/tests/test_force_calculator.py
+++ b/tests/test_force_calculator.py
@@ -1,4 +1,4 @@
-# This file is part of ts_criopy.
+# This file is part of ts_m1m3_utils.
 #
 # Developed for the Rubin Observatory Telescope and Site System.
 # This product includes software developed by the LSST Project

--- a/tests/test_parse_duration.py
+++ b/tests/test_parse_duration.py
@@ -1,4 +1,4 @@
-# This file is part of ts_criopy.
+# This file is part of ts_m1m3_utils.
 #
 # Developed for the Rubin Observatory Telescope and Site System.
 # This product includes software developed by the LSST Project


### PR DESCRIPTION
- **Find following error outliers**
- **DurationTime class**
- **Use DurationParser in m1m3-bump-test-times**
- **Change find_times to generator**
- **Colored output**
